### PR TITLE
use literal non-breaking space, zero-width joiner for code markup

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -6,7 +6,7 @@ Connect the Dots
 This is a collection of some of the
 https://github.com/search?q=dotfiles[dotfiles^] without which I’dn’t’ve learned
 shell scripting, especially with Bash and Zsh, nor’d’ve I been able to craft my
-own&nbsp;`~/.`&zwj;s. The repositories that’ve been most helpful are included
+own `~/.`‍s. The repositories that’ve been most helpful are included
 here as&nbsp;submodules.
 
 Dotfiles


### PR DESCRIPTION
before \`&#126;/.\`
after `~/.`