### PR TITLE
add `--allow-empty` to `git commit` to prevent workflow errors

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -37,7 +37,8 @@ jobs:
           git config --local user.email "action@github.com" && \
           git config --local user.name "GitHub Actions" && \
           git add --verbose --all && \
-          git commit --allow-empty --verbose --message '[ci skip] Updating changelog'
+          git commit --allow-empty --verbose --message \
+          '[ci skip] Updating changelog'
       - name: Push changes
         uses: ad-m/github-push-action@v0.6.0
         with:


### PR DESCRIPTION
- [x] allow changelog entries even when Git believes there’s no change occurring