### PR TITLE
add git registry (fix #505)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,9 @@
 # https://bit.ly/git-io_help-dependabot-configuration
 
 version: 2
+
 enable-beta-ecosystems: true
+
 updates:
 
   # Bundler

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,13 @@ version: 2
 
 enable-beta-ecosystems: true
 
+registries:
+  herrbischoff:
+    type: git
+    url: https://git.herrbischoff.com
+    username: x-access-token
+    password: ${{ secrets.TOKEN }}
+
 updates:
 
   # Bundler
@@ -73,6 +80,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    registries: "*"
     ignore:
       # ignore patch updates for all dependencies
       - dependency-name: "*"


### PR DESCRIPTION
prevent Dependabot from choking on a non-GitHub/non-GitLab submodule; fix #505 with help from [driesvints/driesvints.com@`33423165c5`/.github/dependabot.yml&#8239;#L11](https://github.com/driesvints/driesvints.com/blob/33423165c5/.github/dependabot.yml#L11).

> ⚠️  **Dependabot failed to update your dependencies**
> The following git repository was unreachable and caused the update to fail: [dotpr0n](https://git.herrbischoff.com/dotpr0n).
>
> Dependabot can't update dependency files that reference private git repositories hosted on external sites. Please consider using a [git registry](https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates#git).
>
> Public repositories don’t support updating dependency files that reference private git repositories. Please consider using a [git registry](https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates#git).
>
> Personal user accounts don't support updating dependency files that reference private git repositories. To use Dependabot with dependency files that reference private git repositories, you can use a [git registry](https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates#git), or you can use an [organization account](https://docs.github.com/en/free-pro-team@latest/github/getting-started-with-github/types-of-github-accounts#organization-accounts) and [grant Dependabot access to private repositories](https://docs.github.com/en/free-pro-team@latest/github/setting-up-and-managing-organizations-and-teams/managing-security-and-analysis-settings-for-your-organization#allowing-dependabot-to-access-private-repositories).
>
> [Learn more](https://docs.github.com/github/managing-security-vulnerabilities/troubleshooting-dependabot-errors)
