### PR TITLE
add additional offsite registry for submodule (#505, #506)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,12 @@ registries:
     username: x-access-token
     password: ${{ secrets.TOKEN }}
 
+  sircmpwn:
+    type: git
+    url: https://git.sr.ht
+    username: x-access-token
+    password: ${{ secrets.TOKEN }}
+
 updates:
 
   # Bundler

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ version: 2
 enable-beta-ecosystems: true
 
 registries:
+
   herrbischoff:
     type: git
     url: https://git.herrbischoff.com


### PR DESCRIPTION
prevent Dependabot from choking on a non-GitHub/non-GitLab submodule; fix #505<sup>(#506)</sup>