### PR TITLE
update URLs after `victor-engmark` → `engmark` rename

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -54,4 +54,4 @@
 	url = https://git.sr.ht/~sircmpwn/dotfiles
 [submodule "victor-engmark"]
 	path = victor-engmark
-	url = https://gitlab.com/victor-engmark/tilde.git
+	url = https://gitlab.com/engmark/tilde.git

--- a/readme.adoc
+++ b/readme.adoc
@@ -44,7 +44,7 @@ repositories that’ve been most helpful are included here as&nbsp;submodules.
   Irish^]
 * https://github.com/TimButters/dotfiles/blob/3e03c81fef94d46a7e8f3a63156aa2e928215d4a/zshrc#L46-L50[Tim
   Butters^]
-* https://gitlab.com/victor-engmark/tilde/commit/94413fd4831ba406a814ee1f3bc7d4839870e1ae[Victor
+* https://gitlab.com/engmark/tilde/commit/94413fd4831ba406a814ee1f3bc7d4839870e1ae[Victor
   Engmark^]
 * https://github.com/xero/dotfiles/blob/c8fa7984099a71378839d8796553b73f41113e90/bin/bin/gitio[Xero
   Harrison^]


### PR DESCRIPTION
repair linkrot after [owner change](gitlab.com/engmark/tilde/compare/ae1ea41fe3...0516d40b39):
`gitlab.com/victor-engmark` →
`gitlab.com/vengmark` →
`gitlab.com/engmark`
