### PR TITLE
use human- and browser-accessible links to submodules (#635)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,54 +1,54 @@
 [submodule "MarcCornellà"]
 	path = mcornella
-	url = git@github.com:mcornella/dotfiles.git
+	url = https://github.com/mcornella/dotfiles
 [submodule "MathiasBynens"]
 	path = MathiasBynens
-	url = git@github.com:mathiasbynens/dotfiles.git
+	url = https://github.com/mathiasbynens/dotfiles
 [submodule "BrianUstas"]
 	path = ustasb
-	url = git@github.com:ustasb/dotfiles.git
+	url = https://github.com/ustasb/dotfiles
 [submodule "MarcoFerrari"]
 	path = ferrarimarco
-	url = git@github.com:ferrarimarco/dotfiles.git
+	url = https://github.com/ferrarimarco/dotfiles
 [submodule "BillyWayneMcCann"]
 	path = exergonic
-	url = git@github.com:exergonic/dotfiles.git
+	url = https://github.com/exergonic/dotfiles
 [submodule "LarsKappert"]
 	path = webpro
-	url = git@github.com:webpro/dotfiles.git
+	url = https://github.com/webpro/dotfiles
 [submodule "MarcelBischoff"]
 	path = herrbischoff
 	url = https://git.herrbischoff.com/dotpr0n
 [submodule "GeorgeGritsouk"]
 	path = gggritso
-	url = git@github.com:gggritso/dotfiles.git
+	url = https://github.com/gggritso/dotfiles
 [submodule "TimButters"]
 	path = TimButters
-	url = git@github.com:TimButters/dotfiles.git
+	url = https://github.com/TimButters/dotfiles
 [submodule "GregHurrell"]
 	path = wincent
-	url = git@github.com:wincent/wincent.git
+	url = https://github.com/wincent/wincent
 [submodule "NicolaPaolucci"]
 	path = durdn
-	url = git@github.com:durdn/cfg.git
+	url = https://github.com/durdn/cfg
 [submodule "PaulIrish"]
 	path = PaulIrish
-	url = git@github.com:paulirish/dotfiles.git
+	url = https://github.com/paulirish/dotfiles
 [submodule "xero"]
 	path = xero
-	url = git@github.com:xero/dotfiles.git
+	url = https://github.com/xero/dotfiles
 [submodule "DriesVints"]
 	path = DriesVints
-	url = git@github.com:driesvints/dotfiles.git
+	url = https://github.com/driesvints/dotfiles
 [submodule "arp242"]
 	path = arp242
-	url = git@github.com:arp242/dotfiles.git
+	url = https://github.com/arp242/dotfiles
 [submodule "mislav"]
 	path = mislav
-	url = git@github.com:mislav/dotfiles.git
+	url = https://github.com/mislav/dotfiles
 [submodule "awdeorio"]
 	path = awdeorio
-	url = git@github.com:awdeorio/dotfiles.git
+	url = https://github.com/awdeorio/dotfiles
 [submodule "sircmpwn"]
 	path = sircmpwn
 	url = https://git.sr.ht/~sircmpwn/dotfiles


### PR DESCRIPTION
to fix #635:
- [x] the links in `.gitmodules` change to their HTTPS variants, and
- [x] the HTTPS links in `.gitmodules` end with `.git` only if hosted on GitLab software.
